### PR TITLE
update regex for EndTime and StartTime

### DIFF
--- a/src/main/java/seedu/task/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/task/logic/commands/AddCommand.java
@@ -18,7 +18,7 @@ public class AddCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a task to the task manager. "
             + "Parameters: NAME s/START TIME e/END TIME l/location  [#/TAG]...\n"
             + "Example: " + COMMAND_WORD
-            + " John Doe s/9876hrs e/1111hrs l/311, Clementi Ave 2, #02-25 #/friends #/owesMoney";
+            + " Meet John Doe s/12:59 e/23:59 l/311, Clementi Ave 2, #02-25 #/friends #/owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New task added: %1$s";
     public static final String MESSAGE_DUPLICATE_TASK = "This task already exists in the task manager";

--- a/src/main/java/seedu/task/model/person/EndTime.java
+++ b/src/main/java/seedu/task/model/person/EndTime.java
@@ -10,8 +10,8 @@ import seedu.task.commons.exceptions.IllegalValueException;
 public class EndTime {
 
     public static final String MESSAGE_ENDTIME_CONSTRAINTS =
-            "Task start times should be in hhmm hrs format";
-    public static final String ENDTIME_VALIDATION_REGEX = "^([0-9]{4})+(hrs)";
+            "Task start times should be in hh:mm format";
+    public static final String ENDTIME_VALIDATION_REGEX = "([01]?[0-9]|2[0-3]):[0-5][0-9]";
 
     public final String value;
 

--- a/src/main/java/seedu/task/model/person/StartTime.java
+++ b/src/main/java/seedu/task/model/person/StartTime.java
@@ -8,8 +8,8 @@ import seedu.task.commons.exceptions.IllegalValueException;
  */
 public class StartTime {
 
-    public static final String MESSAGE_STARTTIME_CONSTRAINTS = "Task start times should be in hhmm hrs format";
-    public static final String STARTTIME_VALIDATION_REGEX = "^([0-9]{4})+(hrs)";
+    public static final String MESSAGE_STARTTIME_CONSTRAINTS = "Task start times should be in hh:mm format";
+    public static final String STARTTIME_VALIDATION_REGEX = "([01]?[0-9]|2[0-3]):[0-5][0-9]";
 
     public final String value;
 


### PR DESCRIPTION
Changed format from HHMMhrs to HH:MM.
Updated regex for HH:MM, allowing only valid times.
